### PR TITLE
msm: kgsl: Increase worker thread priority

### DIFF
--- a/drivers/gpu/msm/kgsl.c
+++ b/drivers/gpu/msm/kgsl.c
@@ -5121,7 +5121,7 @@ static void kgsl_core_exit(void)
 static int __init kgsl_core_init(void)
 {
 	int result = 0;
-	struct sched_param param = { .sched_priority = 2 };
+	struct sched_param param = { .sched_priority = 16 };
 
 	/* alloc major and minor device numbers */
 	result = alloc_chrdev_region(&kgsl_driver.major, 0, KGSL_DEVICE_MAX,


### PR DESCRIPTION
Currently, the kgsl worker thread is erroneosly ranked right below
Android's audio threads in terms of priority.

The kgsl worker thread is in the critical path for rendering frames to the
display, so increase its priority to match the priority of MDSS' kthread (mdss_fb0).